### PR TITLE
Updated ColorUtils.Unity.cs to expect float values from Unity's Color class

### DIFF
--- a/SDK/Runner/Utils/ColorUtils.Unity.cs
+++ b/SDK/Runner/Utils/ColorUtils.Unity.cs
@@ -44,7 +44,7 @@ namespace PixelVision8.Runner
         
         public static string RgbToHex(Color color)
         {
-            return "#" + string.Format("{0:X2}{1:X2}{2:X2}", color.r, color.g, color.b);
+            return "#" + string.Format("{0:X2}{1:X2}{2:X2}", (int)(color.r*255), (int)(color.g * 255), (int)(color.b * 255));
         }
     }
 }


### PR DESCRIPTION
Unity's Color class uses [floats on the 0-1 range](https://docs.unity3d.com/ScriptReference/Color.html).

RgbToHex was erroring out while trying to string.Format float values, as string.Format("{0:X2}") only works on integers.